### PR TITLE
Empty description caused error on add field.

### DIFF
--- a/src/Plugin/Field/FieldType/ViewModeSelectorItem.php
+++ b/src/Plugin/Field/FieldType/ViewModeSelectorItem.php
@@ -18,12 +18,11 @@ use Drupal\Core\TypedData\DataDefinition;
  * @FieldType(
  *   id = "view_mode_selector",
  *   label = @Translation("View Mode Selector"),
- *   description = @Translation(""),
+ *   description = @Translation("This field stores entity view mode."),
  *   default_widget = "view_mode_selector_radios",
  *   default_formatter = "view_mode_selector",
  * )
  */
-
 class ViewModeSelectorItem extends FieldItemBase {
 
   /**


### PR DESCRIPTION
Empty description causes an error and it is unable to add the field to an entity (D 8.3.1).

> There was a problem creating field View Mode: Plugin (view_mode_selector) instance class "Drupal\view_mode_selector\Plugin\Field\FieldType\ViewModeSelectorItem" does not exist.