### PR TITLE
Fix warnings in view_mode_selector_form_entity_view_display_edit_form_alter

### DIFF
--- a/view_mode_selector.module
+++ b/view_mode_selector.module
@@ -77,10 +77,10 @@ function view_mode_selector_form_entity_view_display_edit_form_alter(&$form, \Dr
 
   if ($view_display->getMode() == 'view_mode_selector') {
     drupal_set_message(t('This is a placeholder view mode from the <a href="@view-mode-selector">View Mode Selector</a> module. It will be replaced with a selected view mode.', [
-      '@view-mode-selector' => Url::fromUri('https://www.drupal.org/project/view_mode_selector'),
+      '@view-mode-selector' => Url::fromUri('https://www.drupal.org/project/view_mode_selector')->toUriString(),
     ]), 'status');
     drupal_set_message(t('The field settings have been disabled by the <a href="@view-mode-selector">View Mode Selector</a> module.', [
-      '@view-mode-selector' => Url::fromUri('https://www.drupal.org/project/view_mode_selector'),
+      '@view-mode-selector' => Url::fromUri('https://www.drupal.org/project/view_mode_selector')->toUriString(),
     ]), 'warning');
     $form['fields']['#disabled'] = TRUE;
   }

--- a/view_mode_selector.module
+++ b/view_mode_selector.module
@@ -71,8 +71,9 @@ function view_mode_selector_entity_view_mode_info_alter(&$view_modes) {
  * Implements hook_form_FORM_ID_alter().
  */
 function view_mode_selector_form_entity_view_display_edit_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  /** @var \Drupal\field_ui\Form\EntityViewDisplayEditForm $form_object */
   $form_object = $form_state->getFormObject();
-  /** @var $view_display \Drupal\Core\Entity\Entity\EntityViewDisplay **/
+  /** @var \Drupal\Core\Entity\Entity\EntityViewDisplay $view_display */
   $view_display = $form_object->getEntity();
 
   if ($view_display->getMode() == 'view_mode_selector') {


### PR DESCRIPTION
`Warning: htmlspecialchars() expects parameter 1 to be string, object given in Drupal\Component\Utility\Html::escape() (line 423 of core/lib/Drupal/Component/Utility/Html.php).
`
![image](https://user-images.githubusercontent.com/11544787/28965395-85fa280e-7919-11e7-887e-931d1e39399e.png)
