### PR TITLE
Add a basic configuration schema.

### DIFF
--- a/config/schema/view_mode_selector.schema.yml
+++ b/config/schema/view_mode_selector.schema.yml
@@ -1,0 +1,25 @@
+field.value.view_mode_selector:
+  type: field.value.*
+  mapping:
+    value:
+      type: string
+
+field.field_settings.view_mode_selector:
+  type: field.field_settings.*
+  mapping:
+    view_modes:
+      type: sequence
+      sequence:
+        type: mapping
+        mapping:
+          enable:
+            type: boolean
+          hide_title:
+            type: boolean
+          icon:
+            type: mapping
+            mapping:
+              fids:
+                type: sequence
+                sequence:
+                  type: integer


### PR DESCRIPTION
This adds a basic configuration schema, so Drupal core's `ConfigSchemaChecker` can successfully validate this module's configuration, which happens during every integration test, for example. Those fail without these schemas.