### PR TITLE
Fix notice: Only variables should be passed by reference

### DIFF
--- a/src/Plugin/Field/FieldWidget/ViewModeSelectorRadios.php
+++ b/src/Plugin/Field/FieldWidget/ViewModeSelectorRadios.php
@@ -21,10 +21,11 @@ class ViewModeSelectorRadios extends ViewModeSelectorWidgetBase {
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $view_mode_keys = array_keys($this->viewModes);
     $element['value'] = $element + [
       '#type' => 'radios',
       '#options' => $this->viewModes,
-      '#default_value' => $items[$delta]->value ?: reset(array_keys($this->viewModes)),
+      '#default_value' => $items[$delta]->value ?: reset($view_mode_keys),
     ];
 
     return $element;

--- a/src/Plugin/Field/FieldWidget/ViewModeSelectorSelect.php
+++ b/src/Plugin/Field/FieldWidget/ViewModeSelectorSelect.php
@@ -20,10 +20,11 @@ class ViewModeSelectorSelect extends ViewModeSelectorWidgetBase {
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $view_mode_keys = array_keys($this->viewModes);
     $element['value'] = $element + [
         '#type' => 'select',
         '#options' => $this->viewModes,
-        '#default_value' => $items[$delta]->value ?: reset(array_keys($this->viewModes)),
+        '#default_value' => $items[$delta]->value ?: reset($view_mode_keys),
       ];
     return $element;
   }


### PR DESCRIPTION
This is exactly similar to https://github.com/drupal-fancy/view_mode_selector/pull/22 except for those extra spaces. Maybe one of these could be merged one day?