### PR TITLE
Added view mode name override function

### DIFF
--- a/config/schema/view_mode_selector.schema.yml
+++ b/config/schema/view_mode_selector.schema.yml
@@ -16,6 +16,8 @@ field.field_settings.view_mode_selector:
             type: boolean
           hide_title:
             type: boolean
+          override_title:
+            type: string
           icon:
             type: mapping
             mapping:

--- a/src/Plugin/Field/FieldType/ViewModeSelectorItem.php
+++ b/src/Plugin/Field/FieldType/ViewModeSelectorItem.php
@@ -97,6 +97,17 @@ class ViewModeSelectorItem extends FieldItemBase {
 //      if ($instance['widget']['type'] == 'view_mode_selector_radios') {
         $element['view_modes'][$view_mode_id]['prefix']['#markup'] = '<div class="settings">';
 
+        $element['view_modes'][$view_mode_id]['override_title'] = [
+          '#type' => 'textfield',
+          '#title' => $this->t('Override title'),
+          '#default_value' => $settings['view_modes'][$view_mode_id]['override_title'] ?? "",
+          '#states' => [
+            'visible' => [
+              'input[name="field[settings][view_modes][' . $view_mode_id . '][enable]"]' => ['checked' => TRUE],
+            ],
+          ],
+        ];
+
         $element['view_modes'][$view_mode_id]['hide_title'] = [
           '#type' => 'checkbox',
           '#title' => t('Hide title'),

--- a/src/Plugin/Field/FieldWidget/ViewModeSelectorWidgetBase.php
+++ b/src/Plugin/Field/FieldWidget/ViewModeSelectorWidgetBase.php
@@ -49,6 +49,10 @@ abstract class ViewModeSelectorWidgetBase extends WidgetBase implements Containe
     // Reduce options by enabled view modes
     foreach (array_keys($view_modes) as $view_mode) {
       if (isset($field_settings['view_modes'][$view_mode]['enable']) && $field_settings['view_modes'][$view_mode]['enable']) {
+        if (isset($field_settings['view_modes'][$view_mode]['override_title']) && strlen($field_settings['view_modes'][$view_mode]['override_title']) > 0) {
+          $view_modes[$view_mode] = $field_settings['view_modes'][$view_mode]['override_title'];
+        }
+
         continue;
       }
       unset($view_modes[$view_mode]);


### PR DESCRIPTION
The main purpose for this PR, is to add a simple text field and be able to configure the name of the view modes for each node.

I took the opportunity and cleaned up the code and made some fixes to follow the code standard recommended by Drupal.

![example-config](https://user-images.githubusercontent.com/12926707/126366800-045b5a7d-0ba7-429d-b42f-c1e313402334.png)
![example-node-edit](https://user-images.githubusercontent.com/12926707/126366805-16bf5f62-c932-429c-9164-c10b972ce05f.png)